### PR TITLE
Improve healthcheck hook

### DIFF
--- a/barterdude/hooks/healthcheck.py
+++ b/barterdude/hooks/healthcheck.py
@@ -1,8 +1,16 @@
-import threading
-
 from barterdude import BarterDude
 from barterdude.hooks import HttpHook
 from aiohttp import web
+from time import time
+from collections import deque
+from bisect import bisect_left
+
+
+def _remove_old(instants: deque, old_timestamp: float):
+    pos = bisect_left(instants, old_timestamp)
+    for i in range(0, pos):
+        instants.popleft()
+    return len(instants)
 
 
 class Healthcheck(HttpHook):
@@ -10,40 +18,38 @@ class Healthcheck(HttpHook):
         self,
         barterdude: BarterDude,
         path: str = "/healthcheck",
-        error_rate: float = 0.05,
-        clear_seconds: int = 10
+        success_rate: float = 0.95,
+        health_window: float = 60.0  # seconds
     ):
-        self.__error_rate = error_rate
-        self.__clear_seconds = clear_seconds
-        self._clear_rates()
+        self.__success_rate = success_rate
+        self.__health_window = health_window
+        self.__success = deque()
+        self.__fail = deque()
         super(Healthcheck, self).__init__(barterdude, path)
 
-    def _clear_rates(self):
-        self.__success = self.__error = 0
-        timer = threading.Timer(self.__clear_seconds, self._clear_rates)
-        timer.daemon = True
-        timer.start()
-
     async def on_success(self, message):
-        self.__success += 1
+        self.__success.append(time())
 
     async def on_fail(self, message, error):
-        self.__error += 1
+        self.__fail.append(time())
 
     async def __call__(self, *args, **kwargs):
-        if self.__success:
-            rate = self.__error/(self.__success + self.__error)
-            if rate >= self.__error_rate:
-                return web.Response(
-                    body=f"Error rate in {rate}, above {self.__error_rate}",
-                    status=500
-                )
-        elif self.__error:
+        old_timestamp = time() - self.__health_window
+        success = _remove_old(self.__success, old_timestamp)
+        fail = _remove_old(self.__fail, old_timestamp)
+        if success == 0 and fail == 0:
             return web.Response(
-                body=f"Only error happened. {self.__error} until now",
+                body="No messages until now",
+                status=200
+            )
+        rate = success / (success + fail)
+        if rate >= self.__success_rate:
+            return web.Response(
+                body=f"Bater like a pro! Success rate: {rate}",
+                status=200
+            )
+        else:
+            return web.Response(
+                body=f"Success rate {rate} bellow {self.__success_rate}",
                 status=500
             )
-        return web.Response(
-            body=f"Bater like a dude! Error rate: {rate}",
-            status=200
-        )

--- a/barterdude/hooks/healthcheck.py
+++ b/barterdude/hooks/healthcheck.py
@@ -25,7 +25,11 @@ class Healthcheck(HttpHook):
         self.__health_window = health_window
         self.__success = deque()
         self.__fail = deque()
+        self.__force_fail = False
         super(Healthcheck, self).__init__(barterdude, path)
+
+    def force_fail(self):
+        self.__force_fail = True
 
     async def on_success(self, message):
         self.__success.append(time())
@@ -34,6 +38,11 @@ class Healthcheck(HttpHook):
         self.__fail.append(time())
 
     async def __call__(self, *args, **kwargs):
+        if self.__force_fail:
+            return web.Response(
+                body="Healthcheck fail called manually",
+                status=500
+            )
         old_timestamp = time() - self.__health_window
         success = _remove_old(self.__success, old_timestamp)
         fail = _remove_old(self.__fail, old_timestamp)

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -4,3 +4,4 @@ coverage==5.0.3
 bandit<2.0.0
 flake8<4.0.0
 asynctest==0.13.0
+freezegun==0.3.14

--- a/tests/test_hooks/test_healthcheck.py
+++ b/tests/test_hooks/test_healthcheck.py
@@ -65,6 +65,17 @@ class TestHealthcheck(TestCase):
             bytes(f"Success rate 0.5 bellow {self.success_rate}", "utf-8")
         )
 
+    async def test_should_fail_when_force_fail_is_called(self):
+        self.healthcheck.force_fail()
+        await self.healthcheck.on_success(None)
+        response = await self.healthcheck()
+        self.assertEqual(response.status, 500)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value,
+            b"Healthcheck fail called manually"
+        )
+
     async def test_should_erase_old_messages(self):
         tick = 7
         with freeze_time(auto_tick_seconds=tick):

--- a/tests/test_hooks/test_healthcheck.py
+++ b/tests/test_hooks/test_healthcheck.py
@@ -1,6 +1,82 @@
-import unittest
-# from unittest.mock import MagicMock
+from asynctest import TestCase
+from freezegun import freeze_time
+from tests.helpers import get_app
+from barterdude.hooks.healthcheck import Healthcheck
 
 
-class TestHealthcheck(unittest.TestCase):
-    pass
+@freeze_time()
+class TestHealthcheck(TestCase):
+    def setUp(self):
+        self.success_rate = 0.9
+        self.health_window = 60.0
+        self.healthcheck = Healthcheck(
+            get_app(),
+            "/healthcheck",
+            self.success_rate,
+            self.health_window
+        )
+
+    async def test_should_pass_healthcheck_when_no_messages(self):
+        response = await self.healthcheck()
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(response.body._value, b"No messages until now")
+
+    async def test_should_pass_healthcheck_when_only_sucess(self):
+        await self.healthcheck.on_success(None)
+        response = await self.healthcheck()
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value,
+            b"Bater like a pro! Success rate: 1.0"
+        )
+
+    async def test_should_pass_healthcheck_when_success_rate_is_high(self):
+        await self.healthcheck.on_fail(None, None)
+        for i in range(0, 9):
+            await self.healthcheck.on_success(None)
+        response = await self.healthcheck()
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value,
+            b"Bater like a pro! Success rate: 0.9"
+        )
+
+    async def test_should_fail_healthcheck_when_only_fail(self):
+        await self.healthcheck.on_fail(None, None)
+        response = await self.healthcheck()
+        self.assertEqual(response.status, 500)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value,
+            bytes(f"Success rate 0.0 bellow {self.success_rate}", "utf-8")
+        )
+
+    async def test_should_fail_healthcheck_when_success_rate_is_low(self):
+        await self.healthcheck.on_success(None)
+        await self.healthcheck.on_fail(None, None)
+        response = await self.healthcheck()
+        self.assertEqual(response.status, 500)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value,
+            bytes(f"Success rate 0.5 bellow {self.success_rate}", "utf-8")
+        )
+
+    async def test_should_erase_old_messages(self):
+        tick = 7
+        with freeze_time(auto_tick_seconds=tick):
+            for i in range(0, 10):
+                await self.healthcheck.on_fail(None, None)
+            await self.healthcheck.on_success(None)
+            response = await self.healthcheck()
+            rate = 1 / (1 + (self.health_window - tick) // tick)
+            self.assertEqual(
+                response.body._value,
+                bytes(
+                    f"Success rate {rate} bellow {self.success_rate}",
+                    "utf-8"
+                )
+            )


### PR DESCRIPTION
Instead of creating a timer, look at all messages failures and sucesses in a
fixed timed window.