### PR TITLE
Fix redacted config variable

### DIFF
--- a/barterdude/conf.py
+++ b/barterdude/conf.py
@@ -10,9 +10,9 @@ BARTERDUDE_DEFAULT_LOG_LEVEL = int(
         "BARTERDUDE_DEFAULT_LOG_LEVEL", logging.INFO
     )
 )
-BARTERDUDE_LOG_REDACTED = bool(os.environ.get(
+BARTERDUDE_LOG_REDACTED = bool(int(os.environ.get(
     "BARTERDUDE_LOG_REDACTED", "1"
-))
+)))
 handler = logging.StreamHandler()
 handler.setFormatter(jsonlogger.JsonFormatter(
     '(levelname) (name) (pathname) (lineno)',


### PR DESCRIPTION
Previously the redacted value would always be true because
`bool("0") = True`.