### PR TITLE
Remove algumas condições de corrida nos testes de integração

### DIFF
--- a/tests_integration/test_rabbitmq_integration.py
+++ b/tests_integration/test_rabbitmq_integration.py
@@ -1,16 +1,18 @@
-import os
 import asyncio
-
-from asynctest import TestCase
-from barterdude import BarterDude
-from barterdude.monitor import Monitor
-from barterdude.hooks.logging import Logging
-from barterdude.message import ValidationException
-from tests_unit.helpers import load_fixture
-from tests_integration.helpers import ErrorHook
-from asyncworker.connections import AMQPConnection
+import os
+from asyncio import Event
 from random import choices
 from string import ascii_uppercase
+
+from asynctest import TestCase
+from asyncworker.connections import AMQPConnection
+from barterdude import BarterDude
+from barterdude.hooks.logging import Logging
+from barterdude.message import ValidationException
+from barterdude.monitor import Monitor
+from tests_unit.helpers import load_fixture
+
+from tests_integration.helpers import ErrorHook
 
 
 class RabbitMQConsumerTest(TestCase):
@@ -78,37 +80,42 @@ class RabbitMQConsumerTest(TestCase):
 
     async def test_process_messages_successfully(self):
         received_messages = set()
+        sync_event = Event()
 
         @self.app.consume_amqp([self.input_queue], coroutines=1)
         async def handler(message):
             nonlocal received_messages
             received_messages.add(message.body["key"])
+            sync_event.set()
 
         await self.app.startup()
         await self.send_all_messages()
-        await asyncio.sleep(1)
 
+        await sync_event.wait()
         for message in self.messages:
             self.assertTrue(message["key"] in received_messages)
 
     async def test_process_messages_successfully_with_validation(self):
         received_messages = set()
+        sync_event = Event()
 
         @self.app.consume_amqp(
             [self.input_queue], coroutines=1, validation_schema=self.schema)
         async def handler(message):
             nonlocal received_messages
             received_messages.add(message.body["key"])
+            sync_event.set()
 
         await self.app.startup()
         await self.send_all_messages()
-        await asyncio.sleep(1)
 
+        await sync_event.wait()
         for message in self.messages:
             self.assertTrue(message["key"] in received_messages)
 
     async def test_process_messages_successfully_even_with_crashed_hook(self):
         received_messages = set()
+        sync_event = Event()
 
         monitor = Monitor(ErrorHook())
 
@@ -117,15 +124,18 @@ class RabbitMQConsumerTest(TestCase):
         async def handler(message):
             nonlocal received_messages
             received_messages.add(message.body["key"])
+            sync_event.set()
 
         await self.app.startup()
         await self.send_all_messages()
-        await asyncio.sleep(1)
 
+        await sync_event.wait()
         for message in self.messages:
             self.assertTrue(message["key"] in received_messages)
 
     async def test_process_one_message_and_publish(self):
+        sync_event = Event()
+
         @self.app.consume_amqp([self.input_queue], coroutines=1)
         async def forward(message):
             await self.app.publish_amqp(
@@ -139,16 +149,18 @@ class RabbitMQConsumerTest(TestCase):
         async def handler(message):
             nonlocal received_message
             received_message = message.body
+            sync_event.set()
 
         await self.app.startup()
         await self.queue_manager.put(
             routing_key=self.input_queue,
             data=self.messages[0]
         )
-        await asyncio.sleep(1)
+        await sync_event.wait()
         self.assertEqual(received_message, self.messages[1])
 
     async def test_process_message_requeue_with_requeue(self):
+        sync_event = Event()
         handler_called = 0
 
         @self.app.consume_amqp([self.input_queue], coroutines=1)
@@ -157,16 +169,18 @@ class RabbitMQConsumerTest(TestCase):
             handler_called = handler_called + 1
             if handler_called < 2:
                 raise Exception()
+            sync_event.set()
 
         await self.app.startup()
         await self.queue_manager.put(
             routing_key=self.input_queue,
             data=self.messages[0]
         )
-        await asyncio.sleep(1)
+        await sync_event.wait()
         self.assertEqual(handler_called, 2)
 
     async def test_process_message_reject_with_requeue(self):
+        sync_event = Event()
         handler_called = 0
 
         @self.app.consume_amqp(
@@ -177,16 +191,18 @@ class RabbitMQConsumerTest(TestCase):
             handler_called = handler_called + 1
             if handler_called < 2:
                 raise Exception()
+            sync_event.set()
 
         await self.app.startup()
         await self.queue_manager.put(
             routing_key=self.input_queue,
             data=self.messages[0]
         )
-        await asyncio.sleep(2)
+        await sync_event.wait()
         self.assertEqual(handler_called, 2)
 
     async def test_process_message_reject_by_validation_with_requeue(self):
+        sync_event = Event()
         handler_called = 0
 
         @self.app.consume_amqp(
@@ -197,16 +213,18 @@ class RabbitMQConsumerTest(TestCase):
             handler_called = handler_called + 1
             if handler_called < 2:
                 raise ValidationException()
+            sync_event.set()
 
         await self.app.startup()
         await self.queue_manager.put(
             routing_key=self.input_queue,
             data=self.messages[0]
         )
-        await asyncio.sleep(2)
+        await sync_event.wait()
         self.assertEqual(handler_called, 2)
 
     async def test_process_message_reject_without_requeue(self):
+        sync_event = Event()
         handler_called = 0
 
         @self.app.consume_amqp(
@@ -216,6 +234,7 @@ class RabbitMQConsumerTest(TestCase):
             nonlocal handler_called
             handler_called = handler_called + 1
             if handler_called < 2:
+                sync_event.set()
                 raise Exception()
 
         await self.app.startup()
@@ -223,10 +242,11 @@ class RabbitMQConsumerTest(TestCase):
             routing_key=self.input_queue,
             data=self.messages[0]
         )
-        await asyncio.sleep(2)
+        await sync_event.wait()
         self.assertEqual(handler_called, 1)
 
     async def test_process_message_reject_by_validation_without_requeue(self):
+        sync_event = Event()
         handler_called = 0
 
         @self.app.consume_amqp(
@@ -235,6 +255,7 @@ class RabbitMQConsumerTest(TestCase):
             nonlocal handler_called
             handler_called = handler_called + 1
             if handler_called < 2:
+                sync_event.set()
                 raise ValidationException()
 
         await self.app.startup()
@@ -242,7 +263,7 @@ class RabbitMQConsumerTest(TestCase):
             routing_key=self.input_queue,
             data=self.messages[0]
         )
-        await asyncio.sleep(2)
+        await sync_event.wait()
         self.assertEqual(handler_called, 1)
 
     async def test_process_message_reject_by_validation_before_handler(self):
@@ -259,10 +280,12 @@ class RabbitMQConsumerTest(TestCase):
             routing_key=self.input_queue,
             data={"wrong": "key"}
         )
-        await asyncio.sleep(1)
         self.assertEqual(handler_called, 0)
 
     async def test_process_messages_and_requeue_only_one(self):
+        first_sync = Event()
+        second_sync = Event()
+
         first_read = set()
         second_read = set()
 
@@ -280,17 +303,21 @@ class RabbitMQConsumerTest(TestCase):
                 if message.body == self.messages[0]:
                     # process only messages[0] again
                     raise Exception()
+                first_sync.set()
             else:
                 second_read.add(value)
+                second_sync.set()
 
         await self.app.startup()
         await self.send_all_messages()
-
         await asyncio.sleep(1)
 
+
+        await first_sync.wait()
         for message in self.messages:
             self.assertTrue(message["key"] in first_read)
 
+        await first_sync.wait()
         self.assertSetEqual(second_read, {self.messages[0]["key"]})
 
     async def test_fails_to_connect_to_rabbitmq(self):

--- a/tests_integration/test_rabbitmq_integration.py
+++ b/tests_integration/test_rabbitmq_integration.py
@@ -80,36 +80,32 @@ class RabbitMQConsumerTest(TestCase):
 
     async def test_process_messages_successfully(self):
         received_messages = set()
-        sync_event = Event()
 
         @self.app.consume_amqp([self.input_queue], coroutines=1)
         async def handler(message):
             nonlocal received_messages
             received_messages.add(message.body["key"])
-            sync_event.set()
 
         await self.app.startup()
         await self.send_all_messages()
 
-        await sync_event.wait()
+        await asyncio.sleep(1)
         for message in self.messages:
             self.assertTrue(message["key"] in received_messages)
 
     async def test_process_messages_successfully_with_validation(self):
         received_messages = set()
-        sync_event = Event()
 
         @self.app.consume_amqp(
             [self.input_queue], coroutines=1, validation_schema=self.schema)
         async def handler(message):
             nonlocal received_messages
             received_messages.add(message.body["key"])
-            sync_event.set()
 
         await self.app.startup()
         await self.send_all_messages()
 
-        await sync_event.wait()
+        await asyncio.sleep(1)
         for message in self.messages:
             self.assertTrue(message["key"] in received_messages)
 
@@ -311,7 +307,6 @@ class RabbitMQConsumerTest(TestCase):
         await self.app.startup()
         await self.send_all_messages()
         await asyncio.sleep(1)
-
 
         await first_sync.wait()
         for message in self.messages:


### PR DESCRIPTION
### Objetivo desse PR

A intenção desse PR é resolver de forma determinística as condições de corrida que existem nos casos de teste. Hoje temos alguns `asyncio.sleep()` para lidar com essas situações e esse PR troca isso (onde foi possível) por uma primitiva de sincronização. Basicamente para garantir que os asserts rodem **após** o handler ter processado a(s) mensagem(s) de teste.

### Mais detalhes

Nesse PR tentei trocar o máximo possível de `asyncio.sleep()` por uma primitiva de sincronização (`asyncio.Event()`), ou seja, agora os testes (onde consegui fazer a troca) levam apenas "o tempo necessário" pra rodar.

Os testes de integração estão, na verdade, testando um protocolo que é naturalmente assíncrono. Mas os testes são síncronos pois as ações precisam acontecer em uma ordem específica, por exemplo, o asserts precisam, **necessariamente**, rodar após o handler receber e processar a mensagem de teste.

Não só isso, em alguns casos, o assert só pode rodar após o pós-processamento do handler (eventos `on_failure()`, `on_success()`, etc) feito pelo próprio barterdude.

Independente dessa modificação ainda não fazer os testes rodarem com asyncworker==0.15.2+ penso que é uma abordagem melhor do que com o uso do `sleep()`. O `sleep()` já estava nos testes para resolver algumas condições de corrida mas sabemos que ele é um paliativo.

Antes dessa modificação os testes de integração rodavam em +- 17s (tínhamos praticamente um sleep() por teste). Com o `asyncio.Event()` estão rodando em +-5.8s e isso porque ainda temos 3 sleep(1) e 1 sleep(2). Ou seja, se conseguirmos eliminar todos os sleeps vamos ter os testes rodando no tempo necessário.


### O que descobri fazendo esse PR

Descobri algumas coisas interessantes fazendo esse PR. Apesar dos testes ainda não passarem com o asyncworker novo, já melhorou bastante pois agora a sincronização está corretamente feita (ainda não em todos os casos, já explico) e isso é suficiente na maioria dos casos.

Uma coisa que reparei foi que quando rodei os testes com asyncworker novo alguns testes demoravam muito pra rodar (pois estavam parados no `await sync_event.wait()`) e quando fui olhar na UI do rabbit existia uma mensagem **unacked**. O que acho que pode estar acontecendo é que a conexão aberta pelo teste anterior continua aberta (mesmo após o `self.app.shutdown()`) e o rabbit entrega a mensagen do teste atual pra essa conexão... Depois do heartbeat acabar e a conexão morrer a mensagen chega nas mãos do handler correto.

Como estamos usando o `asyncio.Event()` pra sincronizar tudo, o teste espera "o tempo que for" e acaba funcionando no final. Essa é uma análise que ainda quero fazer no asyncworker, mas não impede o eventual merge desse PR.

Alguns testes ainda possuem situações de condição de corrida, mesmo com o `Event()`. Basicamente todos os testes que usam o `self.send_all_messages()`, Explico o porque.


Tres desses testes:

- test_process_messages_successfully
- test_process_messages_successfully_with_validation
- test_process_messages_successfully_even_with_crashed_hook

Possuem a mesma situação, que é: Na fila temos um total de `len(self.messages)` e esse handler é registrado com `coroutines=1`, ou seja, esse handler processa uma mensagem por vez. O problema é que da forma como está agora o primeiro handler que rodar é quem libera o `Event()`. Idealmente aqui teríamos que pensar em uma forma de liberar o `Event()` apenas quando **todas** as mensagens tiverem sido processadas.

Um último teste é o `test_process_messages_and_requeue_only_one` que tem uma situação semelhante. Ele é registrado com `coroutines=len(self.messages)`. Isso significa que temos múltiplos handlers, cada um recebendo uma mensagem mas novamente o primeiro handler que tiver a oportunidade vai liberar o `Event()`. Aqui novamente deveríamos liberar apenas quando todas as mensagens foram processadas.


### Alguns testes não consegui remover o sleep. são eles:


- RabbitMQConsumerTest::test_fails_to_connect_to_rabbitmq

Aqui não temos como colocar o sync no handler pois ele não é chamado, afinal esse teste valida justamente que a falha de conexão foi detectada pelo logger. Aqui de fato não sei se temos muito o que pode ser feito.

- TestBarterDude::test_print_logs_redacted

Apesar do sync_event estar dentro do handler, idealmente ele deveria ser usado **após** o `raise`, mas sabemos que não é possível. A mesma situação acontece no `test_print_logs_redacted`.
