### PR TITLE
Removendo uso do aiohttp.web.Request em handlers asyncworker

### DIFF
--- a/barterdude/hooks/__init__.py
+++ b/barterdude/hooks/__init__.py
@@ -1,7 +1,7 @@
-from aiohttp import web
 from abc import ABCMeta, abstractmethod
 from barterdude import BarterDude
 from asyncworker.rabbitmq.message import RabbitMQMessage
+from asyncworker.http.wrapper import RequestWrapper
 
 
 class BaseHook(metaclass=ABCMeta):
@@ -35,7 +35,7 @@ class HttpHook(BaseHook):
             hook=self.__call__
         )
 
-    async def __call__(self, req: web.Request):
+    async def __call__(self, req: RequestWrapper):
         raise NotImplementedError
 
     async def on_success(self, message: RabbitMQMessage):

--- a/barterdude/hooks/healthcheck.py
+++ b/barterdude/hooks/healthcheck.py
@@ -3,6 +3,7 @@ import json
 from barterdude import BarterDude
 from barterdude.hooks import HttpHook
 from asyncworker.rabbitmq.message import RabbitMQMessage
+from asyncworker.http.wrapper import RequestWrapper
 from aiohttp import web
 from time import time
 from collections import deque
@@ -54,7 +55,7 @@ class Healthcheck(HttpHook):
     async def on_connection_fail(self, error: Exception, retries: int):
         self.__connection_fails = retries
 
-    async def __call__(self, req: web.Request):
+    async def __call__(self, req: RequestWrapper):
         if self.__force_fail:
             return _response(500, {
                 "message": "Healthcheck fail called manually"

--- a/requirements/requirements_base.txt
+++ b/requirements/requirements_base.txt
@@ -2,3 +2,4 @@ async-worker==0.15.1
 aioamqp==0.14.0
 python-json-logger==2.0.1
 jsonschema==3.2.0
+pydantic==1.7


### PR DESCRIPTION
O uso do Request do aiohttp foi depreciado no asyncworker 0.11.5 [1]. Esse PR remove o uso desse objeto em uma preparação para que possa ser possível atualizar para novas versões do asyncworker.
