### PR TITLE
MES-1603 - Healthcheck Monitored Modules

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-python latest:3.7
+python 3.7.13

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+python latest:3.7

--- a/barterdude/hooks/healthcheck.py
+++ b/barterdude/hooks/healthcheck.py
@@ -21,10 +21,12 @@ def _response(status, body):
     body["status"] = "ok" if status == 200 else "fail"
     return web.Response(status=status, body=json.dumps(body))
 
+
 class HealthcheckMonitored(ABC):
     @abstractmethod
     def healthcheck(self):
         pass
+
 
 class Healthcheck(HttpHook):
     def __init__(
@@ -92,7 +94,9 @@ class Healthcheck(HttpHook):
         fail = _remove_old(self.__fail, old_timestamp)
 
         if success == 0 and fail == 0:
-            response["message"] = f"No messages in last {self.__health_window}s"
+            response["message"] = (
+                f"No messages in last {self.__health_window}s"
+            )
             return _response(status, response)
 
         rate = success / (success + fail)

--- a/tests_unit/test_hooks/test_healthcheck.py
+++ b/tests_unit/test_hooks/test_healthcheck.py
@@ -6,6 +6,7 @@ from barterdude.hooks.healthcheck import Healthcheck, HealthcheckMonitored
 class HealthcheckMonitoredMock(HealthcheckMonitored):
     def __init__(self, healthy=True):
         self.healthy = healthy
+
     def healthcheck(self):
         return self.healthy
 
@@ -20,7 +21,9 @@ class TestHealthcheck(TestCase):
         self.app = MagicMock()
         self.monitoredModules = {}
         self.app.__iter__.side_effect = lambda: iter(self.monitoredModules)
-        self.app.__getitem__.side_effect = lambda module: self.monitoredModules[module]
+        self.app.__getitem__.side_effect = (
+            lambda module: self.monitoredModules[module]
+        )
         self.healthcheck = Healthcheck(
             self.app,
             "/healthcheck",
@@ -119,7 +122,7 @@ class TestHealthcheck(TestCase):
             '{"message": "Reached max connection fails (3)", "status": "fail"}'
         )
 
-    async def test_should_pass_healthcheck_when_has_one_healthy_monitored_module(self):
+    async def test_should_pass_when_has_one_healthy_monitored_module(self):
         self.monitoredModules = {
             "testModule": HealthcheckMonitoredMock(True)
         }
@@ -128,10 +131,11 @@ class TestHealthcheck(TestCase):
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
             response.body._value.decode('utf-8'),
-            '{"testModule": "ok", "message": "No messages in last 60.0s", "status": "ok"}'
+            '{"testModule": "ok", '
+            '"message": "No messages in last 60.0s", "status": "ok"}'
         )
 
-    async def test_should_pass_healthcheck_when_has_two_healthy_monitored_module(self):
+    async def test_should_pass_when_has_two_healthy_monitored_module(self):
         self.monitoredModules = {
             "testModule1": HealthcheckMonitoredMock(True),
             "testModule2": HealthcheckMonitoredMock(True)
@@ -141,10 +145,11 @@ class TestHealthcheck(TestCase):
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
             response.body._value.decode('utf-8'),
-            '{"testModule1": "ok", "testModule2": "ok", "message": "No messages in last 60.0s", "status": "ok"}'
+            '{"testModule1": "ok", "testModule2": "ok", '
+            '"message": "No messages in last 60.0s", "status": "ok"}'
         )
 
-    async def test_should_fail_healthcheck_when_has_one_failing_monitored_module(self):
+    async def test_should_fail_when_has_one_failing_monitored_module(self):
         self.monitoredModules = {
             "testModule": HealthcheckMonitoredMock(False)
         }
@@ -153,10 +158,11 @@ class TestHealthcheck(TestCase):
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
             response.body._value.decode('utf-8'),
-            '{"testModule": "fail", "message": "No messages in last 60.0s", "status": "fail"}'
+            '{"testModule": "fail", '
+            '"message": "No messages in last 60.0s", "status": "fail"}'
         )
 
-    async def test_should_fail_healthcheck_when_has_two_failing_monitored_module(self):
+    async def test_should_fail_when_has_two_failing_monitored_module(self):
         self.monitoredModules = {
             "testModule1": HealthcheckMonitoredMock(False),
             "testModule2": HealthcheckMonitoredMock(False)
@@ -166,10 +172,11 @@ class TestHealthcheck(TestCase):
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
             response.body._value.decode('utf-8'),
-            '{"testModule1": "fail", "testModule2": "fail", "message": "No messages in last 60.0s", "status": "fail"}'
+            '{"testModule1": "fail", "testModule2": "fail", '
+            '"message": "No messages in last 60.0s", "status": "fail"}'
         )
 
-    async def test_should_fail_healthcheck_when_has_failing_and_healthy_monitored_modules(self):
+    async def test_should_fail_when_has_failing_and_healthy_modules(self):
         self.monitoredModules = {
             "testModule1": HealthcheckMonitoredMock(False),
             "testModule2": HealthcheckMonitoredMock(True)
@@ -179,10 +186,11 @@ class TestHealthcheck(TestCase):
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
             response.body._value.decode('utf-8'),
-            '{"testModule1": "fail", "testModule2": "ok", "message": "No messages in last 60.0s", "status": "fail"}'
+            '{"testModule1": "fail", "testModule2": "ok", '
+            '"message": "No messages in last 60.0s", "status": "fail"}'
         )
 
-    async def test_should_pass_healthcheck_when_has_one_healthy_monitored_module_and_messages(self):
+    async def test_should_pass_when_has_one_healthy_module_and_messages(self):
         self.monitoredModules = {
             "testModule": HealthcheckMonitoredMock(True)
         }
@@ -192,11 +200,12 @@ class TestHealthcheck(TestCase):
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
             response.body._value.decode('utf-8'),
-            '{"testModule": "ok", "message": "Success rate: 1.0 (expected: 0.9)", '
+            '{"testModule": "ok", '
+            '"message": "Success rate: 1.0 (expected: 0.9)", '
             '"fail": 0, "success": 1, "status": "ok"}'
         )
 
-    async def test_should_pass_healthcheck_when_has_one_failing_monitored_module_and_messages(self):
+    async def test_should_pass_when_has_one_failing_module_and_messages(self):
         self.monitoredModules = {
             "testModule": HealthcheckMonitoredMock(False)
         }
@@ -206,7 +215,8 @@ class TestHealthcheck(TestCase):
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
             response.body._value.decode('utf-8'),
-            '{"testModule": "fail", "message": "Success rate: 1.0 (expected: 0.9)", '
+            '{"testModule": "fail", '
+            '"message": "Success rate: 1.0 (expected: 0.9)", '
             '"fail": 0, "success": 1, "status": "fail"}'
         )
 

--- a/tests_unit/test_hooks/test_healthcheck.py
+++ b/tests_unit/test_hooks/test_healthcheck.py
@@ -1,6 +1,13 @@
-from asynctest import TestCase, Mock
+from asynctest import TestCase, MagicMock
 from freezegun import freeze_time
-from barterdude.hooks.healthcheck import Healthcheck
+from barterdude.hooks.healthcheck import Healthcheck, HealthcheckMonitored
+
+
+class HealthcheckMonitoredMock(HealthcheckMonitored):
+    def __init__(self, healthy=True):
+        self.healthy = healthy
+    def healthcheck(self):
+        return self.healthy
 
 
 @freeze_time()
@@ -10,8 +17,12 @@ class TestHealthcheck(TestCase):
     def setUp(self):
         self.success_rate = 0.9
         self.health_window = 60.0
+        self.app = MagicMock()
+        self.monitoredModules = {}
+        self.app.__iter__.side_effect = lambda: iter(self.monitoredModules)
+        self.app.__getitem__.side_effect = lambda module: self.monitoredModules[module]
         self.healthcheck = Healthcheck(
-            Mock(),
+            self.app,
             "/healthcheck",
             self.success_rate,
             self.health_window
@@ -21,7 +32,7 @@ class TestHealthcheck(TestCase):
         await self.healthcheck.before_consume(None)
 
     async def test_should_pass_healthcheck_when_no_messages(self):
-        response = await self.healthcheck(Mock())
+        response = await self.healthcheck(self.app)
         self.assertEqual(response.status, 200)
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
@@ -31,7 +42,7 @@ class TestHealthcheck(TestCase):
 
     async def test_should_pass_healthcheck_when_only_sucess(self):
         await self.healthcheck.on_success(None)
-        response = await self.healthcheck(Mock())
+        response = await self.healthcheck(self.app)
         self.assertEqual(response.status, 200)
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
@@ -44,7 +55,7 @@ class TestHealthcheck(TestCase):
         await self.healthcheck.on_fail(None, None)
         for i in range(0, 9):
             await self.healthcheck.on_success(None)
-        response = await self.healthcheck(Mock())
+        response = await self.healthcheck(self.app)
         self.assertEqual(response.status, 200)
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
@@ -55,7 +66,7 @@ class TestHealthcheck(TestCase):
 
     async def test_should_fail_healthcheck_when_only_fail(self):
         await self.healthcheck.on_fail(None, None)
-        response = await self.healthcheck(Mock())
+        response = await self.healthcheck(self.app)
         self.assertEqual(response.status, 500)
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
@@ -67,7 +78,7 @@ class TestHealthcheck(TestCase):
     async def test_should_fail_healthcheck_when_success_rate_is_low(self):
         await self.healthcheck.on_success(None)
         await self.healthcheck.on_fail(None, None)
-        response = await self.healthcheck(Mock())
+        response = await self.healthcheck(self.app)
         self.assertEqual(response.status, 500)
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
@@ -79,7 +90,7 @@ class TestHealthcheck(TestCase):
     async def test_should_fail_when_force_fail_is_called(self):
         self.healthcheck.force_fail()
         await self.healthcheck.on_success(None)
-        response = await self.healthcheck(Mock())
+        response = await self.healthcheck(self.app)
         self.assertEqual(response.status, 500)
         self.assertEqual(response.content_type, "text/plain")
         self.assertEqual(
@@ -93,7 +104,7 @@ class TestHealthcheck(TestCase):
             for i in range(0, 10):
                 await self.healthcheck.on_fail(None, None)
             await self.healthcheck.on_success(None)
-            response = await self.healthcheck(Mock())
+            response = await self.healthcheck(self.app)
             self.assertEqual(
                 response.body._value.decode('utf-8'),
                 '{"message": "Success rate: 0.125 (expected: 0.9)", '
@@ -102,8 +113,113 @@ class TestHealthcheck(TestCase):
 
     async def test_should_fail_healthcheck_when_fail_to_connect(self):
         await self.healthcheck.on_connection_fail(None, 3)
-        response = await self.healthcheck(Mock())
+        response = await self.healthcheck(self.app)
         self.assertEqual(
             response.body._value.decode('utf-8'),
             '{"message": "Reached max connection fails (3)", "status": "fail"}'
+        )
+
+    async def test_should_pass_healthcheck_when_has_one_healthy_monitored_module(self):
+        self.monitoredModules = {
+            "testModule": HealthcheckMonitoredMock(True)
+        }
+        response = await self.healthcheck(self.app)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value.decode('utf-8'),
+            '{"testModule": "ok", "message": "No messages in last 60.0s", "status": "ok"}'
+        )
+
+    async def test_should_pass_healthcheck_when_has_two_healthy_monitored_module(self):
+        self.monitoredModules = {
+            "testModule1": HealthcheckMonitoredMock(True),
+            "testModule2": HealthcheckMonitoredMock(True)
+        }
+        response = await self.healthcheck(self.app)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value.decode('utf-8'),
+            '{"testModule1": "ok", "testModule2": "ok", "message": "No messages in last 60.0s", "status": "ok"}'
+        )
+
+    async def test_should_fail_healthcheck_when_has_one_failing_monitored_module(self):
+        self.monitoredModules = {
+            "testModule": HealthcheckMonitoredMock(False)
+        }
+        response = await self.healthcheck(self.app)
+        self.assertEqual(response.status, 500)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value.decode('utf-8'),
+            '{"testModule": "fail", "message": "No messages in last 60.0s", "status": "fail"}'
+        )
+
+    async def test_should_fail_healthcheck_when_has_two_failing_monitored_module(self):
+        self.monitoredModules = {
+            "testModule1": HealthcheckMonitoredMock(False),
+            "testModule2": HealthcheckMonitoredMock(False)
+        }
+        response = await self.healthcheck(self.app)
+        self.assertEqual(response.status, 500)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value.decode('utf-8'),
+            '{"testModule1": "fail", "testModule2": "fail", "message": "No messages in last 60.0s", "status": "fail"}'
+        )
+
+    async def test_should_fail_healthcheck_when_has_failing_and_healthy_monitored_modules(self):
+        self.monitoredModules = {
+            "testModule1": HealthcheckMonitoredMock(False),
+            "testModule2": HealthcheckMonitoredMock(True)
+        }
+        response = await self.healthcheck(self.app)
+        self.assertEqual(response.status, 500)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value.decode('utf-8'),
+            '{"testModule1": "fail", "testModule2": "ok", "message": "No messages in last 60.0s", "status": "fail"}'
+        )
+
+    async def test_should_pass_healthcheck_when_has_one_healthy_monitored_module_and_messages(self):
+        self.monitoredModules = {
+            "testModule": HealthcheckMonitoredMock(True)
+        }
+        await self.healthcheck.on_success(None)
+        response = await self.healthcheck(self.app)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value.decode('utf-8'),
+            '{"testModule": "ok", "message": "Success rate: 1.0 (expected: 0.9)", '
+            '"fail": 0, "success": 1, "status": "ok"}'
+        )
+
+    async def test_should_pass_healthcheck_when_has_one_failing_monitored_module_and_messages(self):
+        self.monitoredModules = {
+            "testModule": HealthcheckMonitoredMock(False)
+        }
+        await self.healthcheck.on_success(None)
+        response = await self.healthcheck(self.app)
+        self.assertEqual(response.status, 500)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value.decode('utf-8'),
+            '{"testModule": "fail", "message": "Success rate: 1.0 (expected: 0.9)", '
+            '"fail": 0, "success": 1, "status": "fail"}'
+        )
+
+    async def test_should_pass_healthcheck_when_has_simple_module(self):
+        self.monitoredModules = {
+            "testModule": MagicMock()
+        }
+        await self.healthcheck.on_success(None)
+        response = await self.healthcheck(self.app)
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.content_type, "text/plain")
+        self.assertEqual(
+            response.body._value.decode('utf-8'),
+            '{"message": "Success rate: 1.0 (expected: 0.9)", '
+            '"fail": 0, "success": 1, "status": "ok"}'
         )


### PR DESCRIPTION
The Messaging Team on OLX Brasil has a project where we start some extra modules on BarterDude startup:
```python
@app._BarterDude__app.run_on_startup
async def startup(app_: BarterDude):
    app_["session"] = session = CachedSession(
        cache=CacheBackend(expire_after=settings.CACHE_APIS_IN_SEC)
    )
    app_["email_service"] = emailService = Email(
        acc_client=AccountClient(session),
        ad_client=AdClient(session),
        nu_client=NUClient(session),
        loop=asyncio.get_running_loop(),
    )
    app_["redis"] = redis = Redis()
    app_["emailMonitor"] = EmailMonitor(redis, emailService)
    app_["redisMetrics"] = RedisMetrics(redis)
```
[Check the file on our repo here](https://github.com/olxbr/chat-unread-message-email-worker/blob/main/app/consumer.py#L35-L48)

We'd like to update the healthcheck endpoint so it also checks if some extra modules are working properly.

For exemple, the RedisMetrics is a worker that runs on a separate thread to collect some internal metrics from Redis and register them on Prometheus. We faced a situation where the worker crashed and the thread stopped. We'd like to check that on healthcheck, so the ASG could replace the broken instance automatically for us.

As the BarterDude and AsyncWorker already give the ability to run extra modules on startup and share them using the [DataSharing](https://github.com/olxbr/BarterDude#data-sharing) model, [like in this example](https://github.com/async-worker/async-worker/blob/main/examples/docker-compose-asyncworker-with-metrics/metrics.py#L72-L75), we used that together with the BarterDude Healthcheck module to delivery an easy to implement way to include extra checks on healthcheck.

If the project is already running the extra modules following the mentioned example, all we need to do is make the module to implement the new interface `HealthcheckMonitored` and implement the method `healthcheck`:
```python
from barterdude.hooks.healthcheck import HealthcheckMonitored

class RedisMetrics(HealthcheckMonitored):
    def healthcheck(self):
        return self._thread.is_alive()
```
[Check how simple was to put our RedisMetrics modules under the healthcheck](https://github.com/olxbr/chat-unread-message-email-worker/pull/19/commits/925ca814b07a982b84548788bdb5eb51eda2223d)

Every time the healthcheck endpoint is called, all monitored modules will be automatically checked and included in the result, like this:
```json
{
    "redisMetrics": "ok",
    "message": "Success rate: 1.0 (expected: 0.9)",
    "fail": 0,
    "success": 1,
    "status": "ok"
}
```

Even if you are running your modules independently of the BarterDude startup, you can still inform BarterDude about it so it's included on the healthcheck:
```python
from barterdude import BarterDude
from app.extra_service import ExtraService

extra_service = ExtraService()

barterdude = BarterDude()
barterdude["extra_service"] = extra_service
```
