### PR TITLE
Added feature that enables the creation of an endpoint that call a hook and returns information about its usage

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: ./.eggs/
+exclude: ./.eggs/,./tests_unit/,./tests_integration/

--- a/README.md
+++ b/README.md
@@ -325,7 +325,8 @@ self.add_callback_endpoint(
 				},
 				"properties": {
 					"headers": {
-						"has_failed": false
+						"has_failed": false,
+                        "trace_id": "random_id"
 					}
 				}
 			}

--- a/README.md
+++ b/README.md
@@ -291,6 +291,14 @@ self.add_callback_endpoint(
     hook=self._execute,
 )
 ```
+
+In order to use a mock instance of the barterdude object, you also need to modify the signature of your callback method to receive a optional argument for the barterdude mock. Then you'll have to choose which one to use. Only the callback endpoint calls will pass the barterdude object to your callback.
+
+```python
+async def _execute(rabbitmq_message: RabbitMQMessage, barterdude_arg=None):
+    bd = barterdude_arg if barterdude_arg is not None else barterdude
+```
+
 #### Request and response example:
 ```json
 # Request

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ async def execute(rabbitmq_message: RabbitMQMessage, barterdude_arg=None):
 				"properties": {
 					"headers": {
 						"has_failed": false,
-                        "trace_id": "random_id"
+						"trace_id": "random_id"
 					}
 				}
 			}

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ barterdude.add_callback_endpoint(
 
 #### Forcing side-effects
 
-If you want the message to be published when calling the callback endpoint, you can pass the parameter `should_mock_barterdude: false`. This way the message will be published. Also, you you don't mock the services used by ther worker, all side-effects will happen and you'll have your worker processing your message just like it would be when consuming from a queue.
+If you want the message to be published when calling the callback endpoint, you can pass the parameter `should_mock_barterdude: false`. This way the message will be published. Also, you don't have to mock the services used by your worker, all side-effects will happen and you'll have your worker processing your message just like it would be when consuming from a queue.
 
 #### Request and response example:
 ```json

--- a/README.md
+++ b/README.md
@@ -285,17 +285,17 @@ barterdude.add_endpoint(
 You can also expose an HTTP endpoint that calls the worker's callback to emulate a message being consumed and processed from a queue. This way you can make a request passing a body and header of a message and the response of this request will have all information of what the worker would do without really publishing the message.
 
 ```python
-self.add_callback_endpoint(
+barterdude.add_callback_endpoint(
     routes=["/execute"],
     methods=["POST"],
-    hook=self._execute,
+    hook=execute,
 )
 ```
 
 In order to use a mock instance of the barterdude object, you also need to modify the signature of your callback method to receive a optional argument for the barterdude mock. Then you'll have to choose which one to use. Only the callback endpoint calls will pass the barterdude object to your callback.
 
 ```python
-async def _execute(rabbitmq_message: RabbitMQMessage, barterdude_arg=None):
+async def execute(rabbitmq_message: RabbitMQMessage, barterdude_arg=None):
     bd = barterdude_arg if barterdude_arg is not None else barterdude
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ async def your_consumer(msg: Message): # you receive only one message and we par
         data=msg.body
     )
     if msg.body == "fail":
-    
+
         my_metric.inc() # you can use prometheus metrics
         healthcheck.force_fail() # you can use your hooks inside consumer too
         msg.reject(requeue=False) # You can force to reject a message, exactly equal https://b2wdigital.github.io/async-worker/src/asyncworker/asyncworker.rabbitmq.html#asyncworker.rabbitmq.message.RabbitMQMessage
@@ -266,7 +266,130 @@ This configuration just controls BarterDude's default Logging Hook and doesn't h
 from baterdude.conf import BARTERDUDE_LOG_REDACTED
 ```
 
-### Testing
+## HTTP Endpoints
+
+### Simple endpoints
+
+If you want to expose and HTTP endpoint, you can easily do that to your Barterdude worker by adding a route mapped to a hook.
+
+```python
+barterdude.add_endpoint(
+    routes=["/some_hook"],
+    methods=["GET"],
+    hook=some_hook,
+)
+```
+
+### Barterdude's callback endpoint
+
+You can also expose an HTTP endpoint that calls the worker's callback to emulate a message being consumed and processed from a queue. This way you can make a request passing a body and header of a message and the response of this request will have all information of what the worker would do without really publishing the message.
+
+```python
+self.add_callback_endpoint(
+    routes=["/execute"],
+    methods=["POST"],
+    hook=self._execute,
+)
+```
+#### Request and response example:
+```json
+# Request
+{
+	"body": {
+		"list_id": 105515152
+	},
+	"headers": {
+		"trace_id": "random_id"
+	}
+}
+
+# Response
+{
+	"message_calls": [
+		{
+			"method": "accept",
+			"args": [],
+			"kwargs": {}
+		}
+	],
+	"barterdude_calls": [
+		{
+			"method": "publish_amqp",
+			"args": [],
+			"kwargs": {
+				"exchange": "NEXT_EXCHANGE_TO_BE_CALLED",
+				"data": {
+					"list_id": 1055151521,
+                    "subject": "vendo samsung galaxy s21",
+					"timestamp": 1657231231000
+				},
+				"properties": {
+					"headers": {
+						"has_failed": false
+					}
+				}
+			}
+		}
+	]
+}
+```
+
+### Side-effects
+
+If your callback has side-effects such as inserting a row in a database or updating an API instead of just making read calls, you can use the following helper to mock specific methods of services that are used via dependecy injection and prevent to side-effects from happenning.
+
+When mocking, you need to specify each method you want to mock and what should be returned when it is called. Both sync and async methods can be mocked.
+
+
+```python
+from barterdude.mocks import PartialMockService
+
+barterdude.add_callback_endpoint(
+    routes=["/execute"],
+    methods=["POST"],
+    hook=execute,
+    mock_dependencies=[
+        PartialMockService(
+            service=database_service,          # service instance used by the worker
+            name="database_service",           # named used in the data sharing/dependency injection
+            methods={},                        # sync methods and async methods
+            async_methods={"update_ad": True}  # the dict key is the method's name and the value is its return value
+        ),
+    ]
+)
+```
+
+#### Forcing side-effects
+
+If you want the message to be published when calling the callback endpoint, you can pass the parameter `should_mock_barterdude: false`. This way the message will be published. Also, you you don't mock the services used by ther worker, all side-effects will happen and you'll have your worker processing your message just like it would be when consuming from a queue.
+
+#### Request and response example:
+```json
+# Request
+{
+	"body": {
+		"list_id": 105515152
+	},
+	"headers": {
+		"trace_id": "random_id"
+	},
+    "should_mock": "should_mock_barterdude"
+}
+
+# Response
+{
+	"message_calls": [
+		{
+			"method": "accept",
+			"args": [],
+			"kwargs": {}
+		}
+	]
+    # message will be published, so we won't have information about publish method's calls
+}
+```
+
+## Testing
 
 To test async consumers we recommend `asynctest` lib
 

--- a/README.md
+++ b/README.md
@@ -344,24 +344,17 @@ async def execute(rabbitmq_message: RabbitMQMessage, barterdude_arg=None):
 
 ### Side-effects
 
-If your callback has side-effects such as inserting a row in a database or updating an API instead of just making read calls, you can use the following helper to mock specific methods of services that are used via dependecy injection and prevent to side-effects from happenning.
-
-When mocking, you need to specify each method you want to mock and what should be returned when it is called. Both sync and async methods can be mocked.
-
+If your callback has services with side-effects such as inserting a row in a database or updating an API, you can pass fake instances of these services that are going to be injected to prevent side-effects from happenning.
 
 ```python
-from barterdude.mocks import PartialMockService
-
 barterdude.add_callback_endpoint(
     routes=["/execute"],
     methods=["POST"],
     hook=execute,
     mock_dependencies=[
-        PartialMockService(
-            service=database_service,          # service instance used by the worker
-            name="database_service",           # named used in the data sharing/dependency injection
-            methods={},                        # sync methods and async methods
-            async_methods={"update_ad": True}  # the dict key is the method's name and the value is its return value
+        (
+            fake_database_service,  # fake service instance to be used by the worker
+            "database_service",     # name used in the data sharing/dependency injection
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ async def execute(rabbitmq_message: RabbitMQMessage, barterdude_arg=None):
 				"exchange": "NEXT_EXCHANGE_TO_BE_CALLED",
 				"data": {
 					"list_id": 1055151521,
-                    "subject": "vendo samsung galaxy s21",
+					"subject": "vendo samsung galaxy s21",
 					"timestamp": 1657231231000
 				},
 				"properties": {

--- a/README.md
+++ b/README.md
@@ -287,7 +287,6 @@ You can also expose an HTTP endpoint that calls the worker's callback to emulate
 ```python
 barterdude.add_callback_endpoint(
     routes=["/execute"],
-    methods=["POST"],
     hook=execute,
 )
 ```

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -42,7 +42,6 @@ class BarterDude(MutableMapping):
     def add_callback_endpoint(
         self,
         routes: Iterable[str],
-        methods: Iterable[str],
         hook: Callable,
         mock_dependencies: Iterable[PartialMockService] = None,
     ):
@@ -51,7 +50,7 @@ class BarterDude(MutableMapping):
 
         self.add_endpoint(
             routes=routes,
-            methods=methods,
+            methods=['POST'],
             hook=hook_to_callback
         )
 

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -89,7 +89,7 @@ class BarterDude(MutableMapping):
 
         response['message_calls'] = rabbitmq_message_mock.get_calls()
 
-        if barterdude_mock:
+        if barterdude_mock is not None:
             response['barterdude_calls'] = barterdude_mock.get_calls()
 
         return web.Response(status=200, body=json.dumps(response))

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -69,7 +69,9 @@ class BarterDude(MutableMapping):
         if body is None:
             return web.Response(
                 status=400,
-                body=json.dumps({'msg': 'Missing "body" attribute in payload.'})
+                body=json.dumps({
+                    'msg': 'Missing "body" attribute in payload.'
+                })
             )
 
         rabbitmq_message_mock = RabbitMQMessageMock(body, headers)
@@ -82,7 +84,7 @@ class BarterDude(MutableMapping):
 
         try:
             await hook(rabbitmq_message_mock, barterdude=barterdude_mock)
-        except Exception as e:
+        except Exception:
             response['exception'] = traceback.format_exc()
 
         response['message_calls'] = rabbitmq_message_mock.get_calls()

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -7,11 +7,10 @@ from asyncworker.options import Options
 from asyncworker.connections import AMQPConnection
 from asyncworker.rabbitmq.message import RabbitMQMessage
 from collections import MutableMapping
-from typing import Iterable, Optional, Callable
+from typing import Iterable, Optional, Callable, Any
 from barterdude.monitor import Monitor
 from barterdude.message import MessageValidation, ValidationException
 from barterdude.mocks import RabbitMQMessageMock, BarterdudeMock
-from barterdude.mocks import PartialMockService
 
 
 class BarterDude(MutableMapping):
@@ -43,7 +42,7 @@ class BarterDude(MutableMapping):
         self,
         routes: Iterable[str],
         hook: Callable,
-        mock_dependencies: Iterable[PartialMockService] = None,
+        mock_dependencies: Iterable[Any] = None,
     ):
         def hook_to_callback(req):
             return self._call_callback_endpoint(req, hook, mock_dependencies)
@@ -58,7 +57,7 @@ class BarterDude(MutableMapping):
         self,
         request: web.Request,
         hook: Callable,
-        mock_dependencies: Iterable[PartialMockService],
+        mock_dependencies: Iterable[Any],
     ):
         payload = await request.json()
         body = payload.get('body')

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -7,7 +7,7 @@ from asyncworker.options import Options
 from asyncworker.connections import AMQPConnection
 from asyncworker.rabbitmq.message import RabbitMQMessage
 from collections import MutableMapping
-from typing import Iterable, Optional, Callable, Any
+from typing import Iterable, Optional, Callable, Any, Tuple
 from barterdude.monitor import Monitor
 from barterdude.message import MessageValidation, ValidationException
 from barterdude.mocks import RabbitMQMessageMock, BarterdudeMock
@@ -42,7 +42,7 @@ class BarterDude(MutableMapping):
         self,
         routes: Iterable[str],
         hook: Callable,
-        mock_dependencies: Iterable[Any] = None,
+        mock_dependencies: Iterable[Tuple[Any, str]] = None,
     ):
         def hook_to_callback(req):
             return self._call_callback_endpoint(req, hook, mock_dependencies)
@@ -57,7 +57,7 @@ class BarterDude(MutableMapping):
         self,
         request: web.Request,
         hook: Callable,
-        mock_dependencies: Iterable[Any],
+        mock_dependencies: Iterable[Tuple[Any, str]],
     ):
         payload = await request.json()
         body = payload.get('body')

--- a/barterdude/mocks.py
+++ b/barterdude/mocks.py
@@ -5,7 +5,7 @@ from typing import Dict, Any, Iterable
 
 class MockWithAssignment(Mock):
     def __init__(self, *args, **kwargs):
-        super(Mock, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__data = {}
 
     def __setitem__(self, key, value):

--- a/barterdude/mocks.py
+++ b/barterdude/mocks.py
@@ -1,6 +1,18 @@
 import asyncio
-from asynctest.mock import Mock, CoroutineMock
+from unittest.mock import Mock
 from typing import Dict, Any, Iterable
+
+
+class AsyncMock(Mock):
+
+    def __call__(self, *args, **kwargs):
+        sup = super(AsyncMock, self)
+        async def coro():
+            return sup.__call__(*args, **kwargs)
+        return coro()
+
+    def __await__(self):
+        return self().__await__()
 
 
 class MockWithAssignment(Mock):
@@ -82,7 +94,7 @@ class BarterdudeMock(MockWithAssignment):
         **kwargs
     ):
         super().__init__(*args, **kwargs)
-        self.publish_amqp = CoroutineMock()
+        self.publish_amqp = AsyncMock()
         if mock_dependencies:
             for dependency in mock_dependencies:
                 self[dependency._name] = dependency

--- a/barterdude/mocks.py
+++ b/barterdude/mocks.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, Any, Iterable
+from typing import Dict, Any, Iterable, Tuple
 from collections import MutableMapping
 from aioamqp.properties import Properties
 
@@ -60,7 +60,7 @@ class RabbitMQMessageMock(ObjectWithCallsTracking):
 class BarterdudeMock(MutableMapping, ObjectWithCallsTracking):
     def __init__(
         self,
-        mock_dependencies: Iterable[Any] = None,
+        mock_dependencies: Iterable[Tuple[Any, str]] = None,
         *args,
         **kwargs
     ):

--- a/barterdude/mocks.py
+++ b/barterdude/mocks.py
@@ -71,7 +71,7 @@ class BarterdudeMock(MutableMapping, ObjectWithCallsTracking):
             for service, name in mock_dependencies:
                 self[name] = service
 
-    async def publish_amqp(*args, **kwargs):
+    async def publish_amqp(self, *args, **kwargs):
         pass
 
     def __getitem__(self, key):

--- a/barterdude/mocks.py
+++ b/barterdude/mocks.py
@@ -7,6 +7,7 @@ class AsyncMock(Mock):
 
     def __call__(self, *args, **kwargs):
         sup = super(AsyncMock, self)
+
         async def coro():
             return sup.__call__(*args, **kwargs)
         return coro()

--- a/barterdude/mocks.py
+++ b/barterdude/mocks.py
@@ -1,0 +1,88 @@
+import asyncio
+from asynctest.mock import Mock, CoroutineMock
+from typing import Dict, Any, Iterable
+
+
+class MockWithAssignment(Mock):
+    def __init__(self, *args, **kwargs):
+        super(Mock, self).__init__(*args, **kwargs)
+        self.__data = {}
+
+    def __setitem__(self, key, value):
+        self.__data[key] = value
+
+    def __getitem__(self, key):
+        return self.__data[key]
+
+    def __delitem__(self, key):
+        del self.__data[key]
+
+    def __len__(self):
+        return len(self.__data)
+
+    def __iter__(self):
+        return iter(self.__data)
+
+    def get_calls(self):
+        return [
+            {'method': method, 'args': args, 'kwargs': kwargs}
+            for method, args, kwargs in self.method_calls
+        ]
+
+
+class PartialMockService:
+    def __init__(
+        self,
+        service: Any,
+        name: str,
+        methods: Dict = None,
+        async_methods: Dict = None
+    ):
+        self._service = service
+        self._name = name
+        self._methods = methods or {}
+        self._async_methods = async_methods or {}
+
+    def __getattr__(self, name):
+        if hasattr(self._service, name):
+            attr = getattr(self._service, name)
+            if hasattr(attr, '__call__'):
+                def replace_method(*args, **kwargs):
+                    if name in self._methods:
+                        return self._methods[name]
+                    if name in self._async_methods:
+                        future = asyncio.Future()
+                        future.set_result(self._async_methods[name])
+                        return future
+                    return attr(*args, **kwargs)
+                return replace_method
+            else:
+                return attr
+
+
+class RabbitMQMessageMock(MockWithAssignment):
+    def __init__(
+        self,
+        body: Dict = None,
+        headers: Dict = None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.body = body
+        self.properties = MockWithAssignment()
+        self.properties.headers = headers
+
+
+class BarterdudeMock(MockWithAssignment):
+    def __init__(
+        self,
+        mock_dependencies: Iterable[PartialMockService] = None,
+        *args,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.publish_amqp = CoroutineMock()
+        if mock_dependencies:
+            for dependency in mock_dependencies:
+                self[dependency._name] = dependency

--- a/requirements/requirements_base.txt
+++ b/requirements/requirements_base.txt
@@ -2,4 +2,3 @@ async-worker==0.15.1
 aioamqp==0.14.0
 python-json-logger==2.0.1
 jsonschema==3.2.0
-asynctest==0.13.0

--- a/requirements/requirements_base.txt
+++ b/requirements/requirements_base.txt
@@ -2,3 +2,4 @@ async-worker==0.15.1
 aioamqp==0.14.0
 python-json-logger==2.0.1
 jsonschema==3.2.0
+asynctest==0.13.0

--- a/tests_unit/test__init__.py
+++ b/tests_unit/test__init__.py
@@ -98,6 +98,8 @@ class TestBarterDude(TestCase):
         service_mock.method_one.assert_called_once()
         service_mock.method_two.assert_called_once()
         assert response.status == 200
+        assert b'message_calls' in response.body._value
+        assert b'barterdude_calls' in response.body._value
 
     async def test_should_hook_call_on_callback_endpoint_without_body(self):
         async def mock_hook(message, barterdude):
@@ -118,6 +120,7 @@ class TestBarterDude(TestCase):
         service_mock.method_one.assert_not_called()
         service_mock.method_two.assert_not_called()
         assert response.status == 400
+        assert response.body._value == b'{"msg": "Missing \\"body\\" attribute in payload."}'
 
     async def test_should_hook_call_on_callback_endpoint_with_exception(self):
         async def mock_hook(message, barterdude):
@@ -132,6 +135,7 @@ class TestBarterDude(TestCase):
 
         request.json.assert_called_once()
         assert response.status == 200
+        assert b'exception' in response.body._value
 
     async def test_should_hook_call_on_callback_endpoint_with_dependency(self):
         async def mock_hook(message, barterdude):
@@ -156,6 +160,8 @@ class TestBarterDude(TestCase):
         service_mock.method_one.assert_called_once()
         service_mock.method_two.assert_not_called()
         assert response.status == 200
+        assert b'message_calls' in response.body._value
+        assert b'barterdude_calls' in response.body._value
 
     async def test_should_call_callback_for_each_message(self):
         self.barterdude.consume_amqp(["queue"], self.monitor)(self.callback)

--- a/tests_unit/test__init__.py
+++ b/tests_unit/test__init__.py
@@ -133,7 +133,7 @@ class TestBarterDude(TestCase):
         request.json.assert_called_once()
         assert response.status == 200
 
-    async def test_should_hook_call_on_callback_endpoint_with_dependecy(self):
+    async def test_should_hook_call_on_callback_endpoint_with_dependency(self):
         async def mock_hook(message, barterdude):
             barterdude['service'].method_one()
             barterdude['service'].method_two()

--- a/tests_unit/test__init__.py
+++ b/tests_unit/test__init__.py
@@ -2,7 +2,6 @@ from asynctest import Mock, TestCase, CoroutineMock, patch, call
 from asyncworker import Options, RouteTypes
 from barterdude import BarterDude
 from barterdude.message import Message
-from barterdude.mocks import PartialMockService
 from tests_unit.helpers import load_fixture
 
 
@@ -69,7 +68,7 @@ class TestBarterDude(TestCase):
         self.barterdude.add_callback_endpoint(
             ['/my_route'],
             hook,
-            PartialMockService(Mock(), 'service')
+            [(Mock(), 'service')]
         )
         self.app.route.assert_called_once_with(
             routes=['/my_route'],
@@ -83,13 +82,14 @@ class TestBarterDude(TestCase):
             barterdude['service'].method_one()
             await barterdude['service'].method_two()
             message.accept()
+            await barterdude.publish_amqp(data={'a': 1})
 
         request = Mock()
         request.json = CoroutineMock(return_value={'body': {}})
         service_mock = Mock()
         service_mock.method_one.return_value = 123
         service_mock.method_two = CoroutineMock(return_value=234)
-        dependencies = [PartialMockService(service_mock, 'service')]
+        dependencies = [(service_mock, 'service')]
         response = await self.barterdude._call_callback_endpoint(
             request, mock_hook, dependencies)
 
@@ -97,21 +97,25 @@ class TestBarterDude(TestCase):
         service_mock.method_one.assert_called_once()
         service_mock.method_two.assert_called_once()
         assert response.status == 200
-        assert b'message_calls' in response.body._value
-        assert b'barterdude_calls' in response.body._value
+        assert response.body._value == (
+            b'{"message_calls": [{"method": "accept", "args": [],'
+            b' "kwargs": {}}], "barterdude_calls": [{"method": '
+            b'"publish_amqp", "args": [], "kwargs": {"data": {"a": 1}}}]}'
+        )
 
     async def test_should_hook_call_on_callback_endpoint_without_body(self):
         async def mock_hook(message, barterdude):
             barterdude['service'].method_one()
             await barterdude['service'].method_two()
             message.accept()
+            await barterdude.publish_amqp(data={'a': 1})
 
         request = Mock()
         request.json = CoroutineMock(return_value={})
         service_mock = Mock()
         service_mock.method_one.return_value = 123
         service_mock.method_two = CoroutineMock(return_value=234)
-        dependencies = [PartialMockService(service_mock, 'service')]
+        dependencies = [(service_mock, 'service')]
         response = await self.barterdude._call_callback_endpoint(
             request, mock_hook, dependencies)
 
@@ -129,39 +133,41 @@ class TestBarterDude(TestCase):
         request = Mock()
         request.json = CoroutineMock(return_value={'body': {}})
         service_mock = Mock()
-        dependencies = [PartialMockService(service_mock, 'service')]
+        dependencies = [(service_mock, 'service')]
         response = await self.barterdude._call_callback_endpoint(
             request, mock_hook, dependencies)
 
         request.json.assert_called_once()
         assert response.status == 200
         assert b'exception' in response.body._value
+        assert b'message_calls' in response.body._value
+        assert b'barterdude_calls' in response.body._value
 
     async def test_should_hook_call_on_callback_endpoint_with_dependency(self):
         async def mock_hook(message, barterdude):
             barterdude['service'].method_one()
             barterdude['service'].method_two()
             message.accept()
+            await barterdude.publish_amqp(data={'a': 1})
 
         request = Mock()
         request.json = CoroutineMock()
         service_mock = Mock()
         service_mock.method_one.return_value = 123
         service_mock.method_two = CoroutineMock(return_value=234)
-        dependencies = [
-            PartialMockService(
-                service_mock, 'service', methods={'method_two': 345}
-            )
-        ]
+        dependencies = [(service_mock, 'service')]
         response = await self.barterdude._call_callback_endpoint(
             request, mock_hook, dependencies)
 
         request.json.assert_called_once()
         service_mock.method_one.assert_called_once()
-        service_mock.method_two.assert_not_called()
+        service_mock.method_two.assert_called_once()
         assert response.status == 200
-        assert b'message_calls' in response.body._value
-        assert b'barterdude_calls' in response.body._value
+        assert response.body._value == (
+            b'{"message_calls": [{"method": "accept", "args": [],'
+            b' "kwargs": {}}], "barterdude_calls": [{"method": '
+            b'"publish_amqp", "args": [], "kwargs": {"data": {"a": 1}}}]}'
+        )
 
     async def test_should_call_callback_for_each_message(self):
         self.barterdude.consume_amqp(["queue"], self.monitor)(self.callback)

--- a/tests_unit/test__init__.py
+++ b/tests_unit/test__init__.py
@@ -120,7 +120,8 @@ class TestBarterDude(TestCase):
         service_mock.method_one.assert_not_called()
         service_mock.method_two.assert_not_called()
         assert response.status == 400
-        assert response.body._value == b'{"msg": "Missing \\"body\\" attribute in payload."}'
+        expected_msg = b'{"msg": "Missing \\"body\\" attribute in payload."}'
+        assert response.body._value == expected_msg
 
     async def test_should_hook_call_on_callback_endpoint_with_exception(self):
         async def mock_hook(message, barterdude):

--- a/tests_unit/test__init__.py
+++ b/tests_unit/test__init__.py
@@ -68,13 +68,12 @@ class TestBarterDude(TestCase):
         hook = Mock()
         self.barterdude.add_callback_endpoint(
             ['/my_route'],
-            ['GET'],
             hook,
             PartialMockService(Mock(), 'service')
         )
         self.app.route.assert_called_once_with(
             routes=['/my_route'],
-            methods=['GET'],
+            methods=['POST'],
             type=RouteTypes.HTTP
         )
         self.decorator.assert_called_once()

--- a/tests_unit/test__init__.py
+++ b/tests_unit/test__init__.py
@@ -119,7 +119,7 @@ class TestBarterDude(TestCase):
         service_mock.method_two.assert_not_called()
         assert response.status == 400
 
-    async def test_should_hook_call_on_callback_endpoint_hook_raising_exception(self):
+    async def test_should_hook_call_on_callback_endpoint_with_exception(self):
         async def mock_hook(message, barterdude):
             raise Exception
 

--- a/tests_unit/test_mocks.py
+++ b/tests_unit/test_mocks.py
@@ -1,108 +1,47 @@
-# from asynctest import TestCase
-# from barterdude.mocks import PartialMockService, MockWithAssignment
-# from barterdude.mocks import BarterdudeMock, RabbitMQMessageMock
+from asynctest import TestCase
+from barterdude.mocks import ObjectWithCallsTracking
+from barterdude.mocks import BarterdudeMock, RabbitMQMessageMock
 
 
-# class Service:
+class TestMocks(TestCase):
 
-#     def __init__(self):
-#         self.x = 10
+    def test_mock_rabbitmqmessage(self):
+        mock = RabbitMQMessageMock({'a': 1}, {'b': 2})
+        mock.accept()
+        mock.reject(requeue=False)
 
-#     def get_string(self):
-#         return 'random_string'
+        assert mock.get_calls() == [
+            {
+                'method': 'accept',
+                'args': (),
+                'kwargs': {}
+            },
+            {
+                'method': 'reject',
+                'args': (),
+                'kwargs': {'requeue': False}
+            },
+        ]
 
-#     def get_number(self):
-#         return 42
+    async def test_mock_barterdude(self):
+        mock = BarterdudeMock()
 
-#     async def get_number_async(self):
-#         return 43
+        mock['value'] = 10
+        await mock.publish_amqp(data={'a': 1})
 
+        assert mock['value'] == 10
+        assert len(mock) == 1
 
-# class TestMockWithAssignment(TestCase):
+        for key in mock:
+            assert key == 'value'
 
-#     def test_mock_should_work_with_assignment(self):
-#         mock = MockWithAssignment()
-#         mock.any_method(123)
-#         mock['any_key'] = 'any_value'
+        del mock['value']
+        assert 'value' not in mock
 
-#         mock.any_method.assert_called_once()
-#         mock.any_method.assert_called_with(123)
-#         assert mock['any_key'] == 'any_value'
-#         assert len(mock) == 1
-
-#         for key in mock:
-#             assert key == 'any_key'
-
-#         del mock['any_key']
-#         assert 'any_key' not in mock
-
-#         assert mock.get_calls() == [{
-#             'method': 'any_method',
-#             'args': (123,),
-#             'kwargs': {}
-#         }]
-
-
-# class TestPartialMockService(TestCase):
-
-#     def setUp(self):
-#         self.service = Service()
-
-#     async def test_without_methods(self):
-#         mock = PartialMockService(self.service, 'service')
-#         assert mock.get_string() == 'random_string'
-#         assert mock.x == 10
-#         assert mock.get_number() == 42
-#         assert await mock.get_number_async() == 43
-
-#     async def test_with_methods(self):
-#         mock = PartialMockService(
-#             self.service,
-#             'service',
-#             methods={'get_number': 44},
-#             async_methods={'get_number_async': 45},
-#         )
-#         assert mock.get_string() == 'random_string'
-#         assert mock.x == 10
-#         assert mock.get_number() == 44
-#         assert await mock.get_number_async() == 45
-
-
-# class TestRabbitMQMessageMock(TestCase):
-
-#     def test_mock_should_have_body_and_headers(self):
-#         body = {'a': 1}
-#         headers = {'b': 2}
-#         mock = RabbitMQMessageMock(body, headers)
-#         mock.accept()
-#         mock.reject(requeue=True)
-#         assert mock.body == body
-#         assert mock.properties.headers == headers
-#         mock.accept.assert_called_once()
-#         mock.reject.assert_called_once()
-#         mock.reject.assert_called_with(requeue=True)
-
-
-# class TestBarterdudeMock(TestCase):
-
-#     def setUp(self):
-#         self.service = Service()
-
-#     async def test_mock_should_have_publish_and_dependencies(self):
-#         dependencies = [
-#             PartialMockService(
-#                 self.service,
-#                 'service',
-#                 methods={'get_number': 44},
-#                 async_methods={'get_number_async': 45},
-#             )
-#         ]
-#         payload = {'data': {'a': 1}}
-#         mock = BarterdudeMock(dependencies)
-#         await mock.publish_amqp(payload)
-#         mock.publish_amqp.assert_called_once()
-#         mock.publish_amqp.assert_called_with(payload)
-#         assert 'service' in mock
-#         assert mock['service'].get_string() == 'random_string'
-#         assert mock['service'].get_number() == 44
-#         assert await mock['service'].get_number_async() == 45
+        assert mock.get_calls() == [
+            {
+                'method': 'publish_amqp',
+                'args': (),
+                'kwargs': {'data': {'a': 1}}
+            },
+        ]

--- a/tests_unit/test_mocks.py
+++ b/tests_unit/test_mocks.py
@@ -1,5 +1,4 @@
 from asynctest import TestCase
-from barterdude.mocks import ObjectWithCallsTracking
 from barterdude.mocks import BarterdudeMock, RabbitMQMessageMock
 
 

--- a/tests_unit/test_mocks.py
+++ b/tests_unit/test_mocks.py
@@ -99,7 +99,7 @@ class TestBarterdudeMock(TestCase):
         ]
         payload = {'data': {'a': 1}}
         mock = BarterdudeMock(dependencies)
-        mock.publish_amqp(payload)
+        await mock.publish_amqp(payload)
         mock.publish_amqp.assert_called_once()
         mock.publish_amqp.assert_called_with(payload)
         assert 'service' in mock

--- a/tests_unit/test_mocks.py
+++ b/tests_unit/test_mocks.py
@@ -1,0 +1,108 @@
+from asynctest import TestCase
+from barterdude.mocks import PartialMockService, MockWithAssignment
+from barterdude.mocks import BarterdudeMock, RabbitMQMessageMock
+
+
+class Service:
+
+    def __init__(self):
+        self.x = 10
+
+    def get_string(self):
+        return 'random_string'
+
+    def get_number(self):
+        return 42
+
+    async def get_number_async(self):
+        return 43
+
+
+class TestMockWithAssignment(TestCase):
+
+    def test_mock_should_work_with_assignment(self):
+        mock = MockWithAssignment()
+        mock.any_method(123)
+        mock['any_key'] = 'any_value'
+
+        mock.any_method.assert_called_once()
+        mock.any_method.assert_called_with(123)
+        assert mock['any_key'] == 'any_value'
+        assert len(mock) == 1
+
+        for key in mock:
+            assert key == 'any_key'
+
+        del mock['any_key']
+        assert 'any_key' not in mock
+
+        assert mock.get_calls() == [{
+            'method': 'any_method',
+            'args': (123,),
+            'kwargs': {}
+        }]
+
+
+class TestPartialMockService(TestCase):
+
+    def setUp(self):
+        self.service = Service()
+
+    async def test_without_methods(self):
+        mock = PartialMockService(self.service, 'service')
+        assert mock.get_string() == 'random_string'
+        assert mock.x == 10
+        assert mock.get_number() == 42
+        assert await mock.get_number_async() == 43
+
+    async def test_with_methods(self):
+        mock = PartialMockService(
+            self.service,
+            'service',
+            methods={'get_number': 44},
+            async_methods={'get_number_async': 45},
+        )
+        assert mock.get_string() == 'random_string'
+        assert mock.x == 10
+        assert mock.get_number() == 44
+        assert await mock.get_number_async() == 45
+
+
+class TestRabbitMQMessageMock(TestCase):
+
+    def test_mock_should_have_body_and_headers(self):
+        body = {'a': 1}
+        headers = {'b': 2}
+        mock = RabbitMQMessageMock(body, headers)
+        mock.accept()
+        mock.reject(requeue=True)
+        assert mock.body == body
+        assert mock.properties.headers == headers
+        mock.accept.assert_called_once()
+        mock.reject.assert_called_once()
+        mock.reject.assert_called_with(requeue=True)
+
+
+class TestBarterdudeMock(TestCase):
+
+    def setUp(self):
+        self.service = Service()
+
+    async def test_mock_should_have_publish_and_dependencies(self):
+        dependencies = [
+            PartialMockService(
+                self.service,
+                'service',
+                methods={'get_number': 44},
+                async_methods={'get_number_async': 45},
+            )
+        ]
+        payload = {'data': {'a': 1}}
+        mock = BarterdudeMock(dependencies)
+        mock.publish_amqp(payload)
+        mock.publish_amqp.assert_called_once()
+        mock.publish_amqp.assert_called_with(payload)
+        assert 'service' in mock
+        assert mock['service'].get_string() == 'random_string'
+        assert mock['service'].get_number() == 44
+        assert await mock['service'].get_number_async() == 45

--- a/tests_unit/test_mocks.py
+++ b/tests_unit/test_mocks.py
@@ -1,108 +1,108 @@
-from asynctest import TestCase
-from barterdude.mocks import PartialMockService, MockWithAssignment
-from barterdude.mocks import BarterdudeMock, RabbitMQMessageMock
+# from asynctest import TestCase
+# from barterdude.mocks import PartialMockService, MockWithAssignment
+# from barterdude.mocks import BarterdudeMock, RabbitMQMessageMock
 
 
-class Service:
+# class Service:
 
-    def __init__(self):
-        self.x = 10
+#     def __init__(self):
+#         self.x = 10
 
-    def get_string(self):
-        return 'random_string'
+#     def get_string(self):
+#         return 'random_string'
 
-    def get_number(self):
-        return 42
+#     def get_number(self):
+#         return 42
 
-    async def get_number_async(self):
-        return 43
-
-
-class TestMockWithAssignment(TestCase):
-
-    def test_mock_should_work_with_assignment(self):
-        mock = MockWithAssignment()
-        mock.any_method(123)
-        mock['any_key'] = 'any_value'
-
-        mock.any_method.assert_called_once()
-        mock.any_method.assert_called_with(123)
-        assert mock['any_key'] == 'any_value'
-        assert len(mock) == 1
-
-        for key in mock:
-            assert key == 'any_key'
-
-        del mock['any_key']
-        assert 'any_key' not in mock
-
-        assert mock.get_calls() == [{
-            'method': 'any_method',
-            'args': (123,),
-            'kwargs': {}
-        }]
+#     async def get_number_async(self):
+#         return 43
 
 
-class TestPartialMockService(TestCase):
+# class TestMockWithAssignment(TestCase):
 
-    def setUp(self):
-        self.service = Service()
+#     def test_mock_should_work_with_assignment(self):
+#         mock = MockWithAssignment()
+#         mock.any_method(123)
+#         mock['any_key'] = 'any_value'
 
-    async def test_without_methods(self):
-        mock = PartialMockService(self.service, 'service')
-        assert mock.get_string() == 'random_string'
-        assert mock.x == 10
-        assert mock.get_number() == 42
-        assert await mock.get_number_async() == 43
+#         mock.any_method.assert_called_once()
+#         mock.any_method.assert_called_with(123)
+#         assert mock['any_key'] == 'any_value'
+#         assert len(mock) == 1
 
-    async def test_with_methods(self):
-        mock = PartialMockService(
-            self.service,
-            'service',
-            methods={'get_number': 44},
-            async_methods={'get_number_async': 45},
-        )
-        assert mock.get_string() == 'random_string'
-        assert mock.x == 10
-        assert mock.get_number() == 44
-        assert await mock.get_number_async() == 45
+#         for key in mock:
+#             assert key == 'any_key'
 
+#         del mock['any_key']
+#         assert 'any_key' not in mock
 
-class TestRabbitMQMessageMock(TestCase):
-
-    def test_mock_should_have_body_and_headers(self):
-        body = {'a': 1}
-        headers = {'b': 2}
-        mock = RabbitMQMessageMock(body, headers)
-        mock.accept()
-        mock.reject(requeue=True)
-        assert mock.body == body
-        assert mock.properties.headers == headers
-        mock.accept.assert_called_once()
-        mock.reject.assert_called_once()
-        mock.reject.assert_called_with(requeue=True)
+#         assert mock.get_calls() == [{
+#             'method': 'any_method',
+#             'args': (123,),
+#             'kwargs': {}
+#         }]
 
 
-class TestBarterdudeMock(TestCase):
+# class TestPartialMockService(TestCase):
 
-    def setUp(self):
-        self.service = Service()
+#     def setUp(self):
+#         self.service = Service()
 
-    async def test_mock_should_have_publish_and_dependencies(self):
-        dependencies = [
-            PartialMockService(
-                self.service,
-                'service',
-                methods={'get_number': 44},
-                async_methods={'get_number_async': 45},
-            )
-        ]
-        payload = {'data': {'a': 1}}
-        mock = BarterdudeMock(dependencies)
-        await mock.publish_amqp(payload)
-        mock.publish_amqp.assert_called_once()
-        mock.publish_amqp.assert_called_with(payload)
-        assert 'service' in mock
-        assert mock['service'].get_string() == 'random_string'
-        assert mock['service'].get_number() == 44
-        assert await mock['service'].get_number_async() == 45
+#     async def test_without_methods(self):
+#         mock = PartialMockService(self.service, 'service')
+#         assert mock.get_string() == 'random_string'
+#         assert mock.x == 10
+#         assert mock.get_number() == 42
+#         assert await mock.get_number_async() == 43
+
+#     async def test_with_methods(self):
+#         mock = PartialMockService(
+#             self.service,
+#             'service',
+#             methods={'get_number': 44},
+#             async_methods={'get_number_async': 45},
+#         )
+#         assert mock.get_string() == 'random_string'
+#         assert mock.x == 10
+#         assert mock.get_number() == 44
+#         assert await mock.get_number_async() == 45
+
+
+# class TestRabbitMQMessageMock(TestCase):
+
+#     def test_mock_should_have_body_and_headers(self):
+#         body = {'a': 1}
+#         headers = {'b': 2}
+#         mock = RabbitMQMessageMock(body, headers)
+#         mock.accept()
+#         mock.reject(requeue=True)
+#         assert mock.body == body
+#         assert mock.properties.headers == headers
+#         mock.accept.assert_called_once()
+#         mock.reject.assert_called_once()
+#         mock.reject.assert_called_with(requeue=True)
+
+
+# class TestBarterdudeMock(TestCase):
+
+#     def setUp(self):
+#         self.service = Service()
+
+#     async def test_mock_should_have_publish_and_dependencies(self):
+#         dependencies = [
+#             PartialMockService(
+#                 self.service,
+#                 'service',
+#                 methods={'get_number': 44},
+#                 async_methods={'get_number_async': 45},
+#             )
+#         ]
+#         payload = {'data': {'a': 1}}
+#         mock = BarterdudeMock(dependencies)
+#         await mock.publish_amqp(payload)
+#         mock.publish_amqp.assert_called_once()
+#         mock.publish_amqp.assert_called_with(payload)
+#         assert 'service' in mock
+#         assert mock['service'].get_string() == 'random_string'
+#         assert mock['service'].get_number() == 44
+#         assert await mock['service'].get_number_async() == 45


### PR DESCRIPTION
Adicionada nova feature que permite a simulação de uma mensagem sendo consumida enviada por chamada HTTP num endpoint definido no worker. A mensagem é consumida porém, por default, não é publicada para nenhuma exchange.

```python
barterdude.add_callback_endpoint(
    routes=["/execute"],
    hook=execute,
)
```

### Request e response:
```json
# Request
{
	"body": {
		"list_id": 105515152
	},
	"headers": {
		"trace_id": "random_id"
	}
}

# Response
{
	"message_calls": [
		{
			"method": "accept",
			"args": [],
			"kwargs": {}
		}
	],
	"barterdude_calls": [
		{
			"method": "publish_amqp",
			"args": [],
			"kwargs": {
				"exchange": "NEXT_EXCHANGE_TO_BE_CALLED",
				"data": {
					"list_id": 1055151521,
                    "subject": "vendo samsung galaxy s21",
					"timestamp": 1657231231000
				},
				"properties": {
					"headers": {
						"has_failed": false,
                                                  "trace_id": "random_id"
					}
				}
			}
		}
	]
}
```

Também é possível mockar parcialmente serviços para evitar side-effects, como por exemplo updates e inserts em bancos de dados:

```python
barterdude.add_callback_endpoint(
    routes=["/execute"],
    hook=execute,
    mock_dependencies=[
        (
            fake_database_service,     # fake service instance used by the worker
            "database_service",           # name used in the data sharing/dependency injection
        ),
    ]
)
```

Se for desejado que o side-effect e a publicação das mensagens ocorram, é possível passar o parametro `should_mock_barterdude: false` no payload do request e a mensagem será processada e publicada assim como se tivesse vinda da fila de produção.

### Request e response:
```json
# Request
{
	"body": {
		"list_id": 105515152
	},
	"headers": {
		"trace_id": "random_id"
	},
        "should_mock_barterdude": false
}

# Response
{
	"message_calls": [
		{
			"method": "accept",
			"args": [],
			"kwargs": {}
		}
	]
    # message will be published, so we won't have information about publish method's calls
}
```