### PR TITLE
FIX: callback endpoint hook

### DIFF
--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -45,7 +45,7 @@ class BarterDude(MutableMapping):
         mock_dependencies: Iterable[Tuple[Any, str]] = None,
     ):
         async def hook_to_callback(req:web.Request):
-            return self._call_callback_endpoint(req, hook, mock_dependencies)
+            return await self._call_callback_endpoint(req, hook, mock_dependencies)
 
         self.add_endpoint(
             routes=routes,

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -45,7 +45,11 @@ class BarterDude(MutableMapping):
         mock_dependencies: Iterable[Tuple[Any, str]] = None,
     ):
         async def hook_to_callback(req: web.Request):
-            return await self._call_callback_endpoint(req, hook, mock_dependencies)
+            return await self._call_callback_endpoint(
+                req,
+                hook,
+                mock_dependencies
+            )
 
         self.add_endpoint(
             routes=routes,

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -44,7 +44,7 @@ class BarterDude(MutableMapping):
         hook: Callable,
         mock_dependencies: Iterable[Tuple[Any, str]] = None,
     ):
-        async def hook_to_callback(req:web.Request):
+        async def hook_to_callback(req: web.Request):
             return await self._call_callback_endpoint(req, hook, mock_dependencies)
 
         self.add_endpoint(

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -44,7 +44,7 @@ class BarterDude(MutableMapping):
         hook: Callable,
         mock_dependencies: Iterable[Tuple[Any, str]] = None,
     ):
-        def hook_to_callback(req):
+        async def hook_to_callback(req):
             return self._call_callback_endpoint(req, hook, mock_dependencies)
 
         self.add_endpoint(

--- a/barterdude/__init__.py
+++ b/barterdude/__init__.py
@@ -44,7 +44,7 @@ class BarterDude(MutableMapping):
         hook: Callable,
         mock_dependencies: Iterable[Tuple[Any, str]] = None,
     ):
-        async def hook_to_callback(req):
+        async def hook_to_callback(req:web.Request):
             return self._call_callback_endpoint(req, hook, mock_dependencies)
 
         self.add_endpoint(

--- a/tests_unit/test__init__.py
+++ b/tests_unit/test__init__.py
@@ -84,7 +84,6 @@ class TestBarterDude(IsolatedAsyncioTestCase):
     async def test_hook_to_callback_should_be_async_and_typed(self):
         bd = BarterDude()
         bd.add_endpoint = Mock()
-        bd._call_callback_endpoint = Mock()
 
         hook = Mock()
         bd.add_callback_endpoint(

--- a/tests_unit/test__init__.py
+++ b/tests_unit/test__init__.py
@@ -1,3 +1,5 @@
+import asyncio
+import typing
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import Mock, AsyncMock, patch, call
 
@@ -78,6 +80,22 @@ class TestBarterDude(IsolatedAsyncioTestCase):
             type=RouteTypes.HTTP
         )
         self.decorator.assert_called_once()
+
+    async def test_hook_to_callback_should_be_async_and_typed(self):
+        bd = BarterDude()
+        bd.add_endpoint = Mock()
+        bd._call_callback_endpoint = Mock()
+
+        hook = Mock()
+        bd.add_callback_endpoint(
+            ['/my_route'],
+            hook,
+            [(Mock(), 'service')]
+        )
+
+        internal_hook = bd.add_endpoint.call_args_list[0][1].get('hook')
+        assert asyncio.iscoroutinefunction(internal_hook) is True
+        assert 'req' in typing.get_type_hints(internal_hook)
 
     async def test_should_hook_call_on_callback_endpoint(self):
         async def mock_hook(message, barterdude):


### PR DESCRIPTION
# what
Fixes the `TypeError` error while using the `add_callback_endpoint` to BarterDude

```bash
Traceback (most recent call last):
  File "/usr/lib64/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/app/elasticsearch_indexer_worker/__main__.py", line 8, in <module>
    app = Consumer()
  File "/app/elasticsearch_indexer_worker/consumer.py", line 94, in __init__
    (datalake_publisher_mock(), "datalake_publisher")
  File "/usr/local/lib/python3.7/site-packages/barterdude/__init__.py", line 53, in add_callback_endpoint
    hook=hook_to_callback
  File "/usr/local/lib/python3.7/site-packages/barterdude/__init__.py", line 39, in add_endpoint
    )(hook)
  File "/usr/local/lib/python3.7/site-packages/asyncworker/app.py", line 140, in wrapper
    f"handler must be a coroutine: {handler}"
TypeError: handler must be a coroutine: <method-wrapper '__call__' of function object at 0x400c8db830>
```

Also fixes the typing error caused by type checking the `hook_to_callback` function and the error caused by not awaiting the `_call_callback_endpoint` coroutine

# why
Without this is fix, we can't run apps with callback hooks

# how
Makes the `hook_to_callback` function a couroutine, adds a typing to the `hook_to_callback` args and awaits for the `_call_callback_endpoint` func

